### PR TITLE
Redo the bottom toolbar to be more responsive using flexbox

### DIFF
--- a/App/style.css
+++ b/App/style.css
@@ -421,7 +421,6 @@ input[valid='false'] {
 --stopbuttonbg: #f46;
 
   transition: left 250ms;
-  bottom: 10px;
   width: min-content;
   box-shadow: 0px 2px 4px 0px rgba(0, 0, 0, 0.4);
   z-index: 2;
@@ -460,6 +459,10 @@ input[valid='false'] {
   border-width: 2px;
   border-style: solid;
   border-color: #000;
+}
+
+#run-button {
+  position: relative;
 }
 
 #run-button:not(:hover) {

--- a/App/style.css
+++ b/App/style.css
@@ -146,6 +146,7 @@ body > .bar {
 }
 .cb-button{
   padding: 8px;
+  margin-right: 4px;
   background: rgba(0, 0, 0, 0);
 }
 
@@ -252,10 +253,10 @@ input[valid='false'] {
 }
 #controls-bar-gfx{
   display: flex;
-  /* position: absolute; */
+  position: relative;
   background: rgb(255 255 255);
   /* width: 100%; */
-  /* height: 100%; */
+  height: 100%;
   border-radius: 0px 5px 0px 0px;
 }
 /* time slider */
@@ -308,7 +309,7 @@ input[valid='false'] {
   background-color: rgb(255, 255, 255);
   height: 3px;
   position: relative;
-  bottom: 30px;
+  bottom: 40px;
   border-style: solid;
   border-width: 2px;
   border-color: black;
@@ -365,9 +366,8 @@ input[valid='false'] {
   --bgcolor: white;
   transition: none;
   transition-delay: 0s;
-  width: 50px;
-  height: 50px;
-  position: relative;
+  position: absolute;
+  bottom: 50px;
   background-image: radial-gradient(circle at 45px 0px, rgba(0, 0, 0, 0) 0, rgba(0, 0, 0, 0) 40px, var(--bgcolor) 40px);
   z-index: 1;
 }
@@ -489,7 +489,13 @@ input[valid='false'] {
 */
 #sound-button{
   width: min-content;
+  font-size: 24px;
 }
+
+#reset-button {
+  margin-left: 30px;
+}
+
 #reset-button > .string {
   font-size: 24px;
   line-height: 14px;

--- a/App/style.css
+++ b/App/style.css
@@ -131,7 +131,6 @@ body > .bar {
   min-width: 30px;
   min-height: 30px;
 
-  padding: 0 8px;
 
   display: flex;
   align-items: center;
@@ -141,9 +140,12 @@ body > .bar {
   transition: 0.2s;
 }
 .button{
+  padding: 0 8px;
+  margin: 10px;
   background: white;
 }
 .cb-button{
+  padding: 8px;
   background: rgba(0, 0, 0, 0);
 }
 
@@ -241,7 +243,7 @@ input[valid='false'] {
   align-self: center;
 
   align-items: flex-end;
-  justify-content: center;
+  justify-content: flex-start;
 
   bottom: 0px;
   left: 0px;
@@ -249,10 +251,11 @@ input[valid='false'] {
   border-radius: 0px 5px 0px 0px;
 }
 #controls-bar-gfx{
-  position: absolute;
+  display: flex;
+  /* position: absolute; */
   background: rgb(255 255 255);
-  width: 100%;
-  height: 100%;
+  /* width: 100%; */
+  /* height: 100%; */
   border-radius: 0px 5px 0px 0px;
 }
 /* time slider */
@@ -261,11 +264,12 @@ input[valid='false'] {
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  position: absolute;
   height: 0px;
-  margin:auto;
-  left: 30px;
-  width: 1px;
+  flex-grow: 1;
+  /* left: 30px;
+  width: 1px; */
+  position: relative;
+  left: 80px;
   bottom: 30px;
 }
 
@@ -303,8 +307,8 @@ input[valid='false'] {
   -webkit-appearance: none;
   background-color: rgb(255, 255, 255);
   height: 3px;
-  bottom: 10px;
-  position: absolute;
+  position: relative;
+  bottom: 30px;
   border-style: solid;
   border-width: 2px;
   border-color: black;
@@ -361,26 +365,22 @@ input[valid='false'] {
   --bgcolor: white;
   transition: none;
   transition-delay: 0s;
-  left: 100%;
   width: 50px;
   height: 50px;
-  bottom: 50px;
-  position: absolute;
+  position: relative;
   background-image: radial-gradient(circle at 45px 0px, rgba(0, 0, 0, 0) 0, rgba(0, 0, 0, 0) 40px, var(--bgcolor) 40px);
-  z-index: -1;
+  z-index: 1;
 }
 #expression-envelope {
   --font-size: 1.5rem;
   transition: transform 1s, opacity 0.2s;
-  bottom: 0px;
-  left: 0px;
   font-size: var(--font-size);
-  position: absolute;
   max-width: min-content;
   height: min-content;
   border-radius: 0px 10px 0px 0px;
   padding: 14px 10px 13px 10px;
   z-index: 1;
+  margin: 0;
 }
 
 
@@ -421,8 +421,6 @@ input[valid='false'] {
 --stopbuttonbg: #f46;
 
   transition: left 250ms;
-  position: fixed;
-  left: calc(100% - 100px);
   bottom: 10px;
   width: min-content;
   box-shadow: 0px 2px 4px 0px rgba(0, 0, 0, 0.4);
@@ -436,13 +434,6 @@ input[valid='false'] {
   animation: pulse 0.5s infinite;
   width: 100px;
   bottom: 60px;
-}
-
-.reset-button {
-  position: absolute;
-
-  right: 0;
-  bottom: 0;
 }
 
 #reset-confirmation-dialog {
@@ -496,18 +487,7 @@ input[valid='false'] {
   background: #68f;
 }
 */
-#reset-button {
-  position: absolute;
-
-  left: calc(100% + 30px);
-  bottom: 10px;
-
-  padding: 0;
-}
 #sound-button{
-  position: absolute;
-  left: calc(100% + 120px);
-  bottom: 10px;
   width: min-content;
 }
 #reset-button > .string {
@@ -606,12 +586,19 @@ input[valid='false'] {
   transition: 0.05s;
 }
 
+.volume-container {
+  /* Set position explicitly on this so that child elements (the slider) with absolute position
+   * use this as a reference point. We don't have to set left/right/bottom/top because we actually
+   * want this positioned wherever flexbox puts it */
+  position: relative;
+}
 
 #volume-slider {
   position: absolute;
   transition-duration: 1s;
-  bottom: 60px;
-  left: calc(100% + 77px);
+  bottom: 45px;
+  left: -45px;
+  transition-duration: 1s;
   writing-mode: lr-tb; /* IE */
   -webkit-appearance: slider-vertical; /* Chromium */
   opacity: 0;
@@ -623,13 +610,8 @@ input[valid='false'] {
 }
 
 #navigator-button {
-  position: absolute;
-  bottom: 10px;
   height: min-content;
   font-size: 1.4rem;
-  width: min-content;
-  left: calc(100% + 70px);
-
 }
 
 #navigator-button > .string {
@@ -939,7 +921,7 @@ input[valid='false'] {
 }
 .tooltip-e,
 .tooltip{
-  z-index: -10;
+  /* z-index: -10; */
 }
 .tooltip::before,
 .tooltip::after {

--- a/Types/Entities/Level.js
+++ b/Types/Entities/Level.js
@@ -728,16 +728,15 @@ function Level(spec) {
   }
   function updateRunButtonPosition(){
     ui.runButton.style.transition = "left 0ms"
-    ui.runButton.style.left = `${ui.controlBar.offsetWidth + 10}px`
-    ui.stopButton.style.left = `${ui.controlBar.offsetWidth + 10}px`
-    
+    // ui.runButton.style.left = `${ui.controlBar.offsetWidth + 10}px`
+    // ui.stopButton.style.left = `${ui.controlBar.offsetWidth + 10}px`
   }
   window.addEventListener("resize", updateUI);
   function updateUI(){
     refreshMathFieldRadius()
     updateHintEquationHeight()
-    updateControlBarWidth()
-    updateTimeSliderPosition()
+    //updateControlBarWidth()
+    //updateTimeSliderPosition()
     updateRunButtonPosition()
   }
   function goalCompleted(goal) {

--- a/index.html
+++ b/index.html
@@ -161,29 +161,10 @@
     </div>
     
     <div class="bar floating controls" id="controls-bar"> 
-      <div id="controls-bar-gfx"></div>
       <div class="button reset-button" id="try-again-button" hide="true">
         <div class="string">Try Again</div>
       </div>
       <div class="bar floating controls" id="expression-envelope" disabled="false">
-        <div id="time-slider-container" class="controls">
-          <div id="time-slider-ticks">
-            <div class="slider-tick"><div class="slider-tick-label">0s</div></div>
-            <div class="slider-tick"><div class="slider-tick-label">1</div></div>
-            <div class="slider-tick"><div class="slider-tick-label">2</div></div>
-            <div class="slider-tick"><div class="slider-tick-label">3</div></div>
-            <div class="slider-tick"><div class="slider-tick-label">4</div></div>
-            <div class="slider-tick"><div class="slider-tick-label">5</div></div>
-            <div class="slider-tick"><div class="slider-tick-label">6</div></div>
-            <div class="slider-tick"><div class="slider-tick-label">7</div></div>
-            <div class="slider-tick"><div class="slider-tick-label">8</div></div>
-            <div class="slider-tick"><div class="slider-tick-label">9</div></div>
-            <div class="slider-tick"><div class="slider-tick-label">10s</div></div>
-          </div>
-          <input type="range" id="time-slider" value="0" min="0" max="100" step="1"  orient="horizontal">
-          
-        </div>
-        <div id="junction" class="controls"></div>
         <div class="label" id="variable-label">
           <div class="string">Y=</div>
         </div>
@@ -191,31 +172,50 @@
         <div id="math-field"></div>
   
         <div id="math-field-static"></div>
-
-        
-        <div class="cb-button tooltip" id="reset-button" data-tooltip="Reset">
+      </div>
+      <div id="controls-bar-gfx">
+        <div id="junction" class="controls"></div>
+        <div class="cb-button" id="reset-button" data-tooltip="Reset">
           <div class="string">↺</div>
         </div>
-        <div class="cb-button tooltip" id="navigator-button" data-tooltip="Map">
+        <div class="cb-button" id="navigator-button" data-tooltip="Map">
           <div class="string">🌎</div>
         </div>
-        <input id="volume-slider" type="range" orient="horizontal" />
-        <div class="cb-button tooltip" id="sound-button" data-tooltip="Volume">🔊</div>
+        <div class="volume-container">
+          <div class="cb-button tooltip" id="sound-button" data-tooltip="Volume">
+            🔊
+          </div>
+          <input id="volume-slider" type="range" orient="horizontal" />
+        </div>
       </div>
 
 
       <input class="text" id="expression-text" type="text" hide="true" />
 
       <div class="button" id="run-button" hide="false">
-
         <div class="string">GO</div>
       </div>
   
       <div class="button reset-button bar floating controls" id="stop-button" hide="true">
         <div class="string">STOP</div>
       </div>
-  
-        <input class="text" id="expression-text" type="text" hide="true" />
+
+      <div id="time-slider-container" class="controls">
+        <div id="time-slider-ticks">
+          <div class="slider-tick"><div class="slider-tick-label">0s</div></div>
+          <div class="slider-tick"><div class="slider-tick-label">1</div></div>
+          <div class="slider-tick"><div class="slider-tick-label">2</div></div>
+          <div class="slider-tick"><div class="slider-tick-label">3</div></div>
+          <div class="slider-tick"><div class="slider-tick-label">4</div></div>
+          <div class="slider-tick"><div class="slider-tick-label">5</div></div>
+          <div class="slider-tick"><div class="slider-tick-label">6</div></div>
+          <div class="slider-tick"><div class="slider-tick-label">7</div></div>
+          <div class="slider-tick"><div class="slider-tick-label">8</div></div>
+          <div class="slider-tick"><div class="slider-tick-label">9</div></div>
+          <div class="slider-tick"><div class="slider-tick-label">10s</div></div>
+        </div>
+        <input type="range" id="time-slider" value="0" min="0" max="100" step="1"  orient="horizontal">
+
       </div>
     </div>
     


### PR DESCRIPTION
Main things I changed
- Change the DOM structure so it actually represents the order of the elements showing on screen
- Instead of `position: absolute`, use padding/margin to get elements to show with right spacing. In the rare case where we had to position something outside of flexbox, use relative/absolute depending on whether we wanted the element to take up its layout space or not. With the volume slider, we had to set an ancestor div to `position: relative` so that the volume slider's absolute would position itself relative to it.
- Remove a few cases of resizing things via javascript